### PR TITLE
fix: prevent Worker hang on GET /mcp by rejecting SSE stream requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,13 +86,26 @@ export default {
       );
     }
 
+    // GET requests attempt to open a long-lived SSE stream for server-initiated messages.
+    // This hangs in stateless Cloudflare Workers (no persistent server context to push events),
+    // causing the runtime to kill the request as "hung".
+    if (request.method === 'GET') {
+      return new Response(null, {
+        status: 405,
+        headers: { Allow: 'POST, DELETE, OPTIONS', ...CORS_HEADERS },
+      });
+    }
+
     // Create fresh client + server per request to prevent cross-client data leaks
     const client = new DAAdminClient({ apiToken: token, daadminService: env.daadmin });
     const server = createServer(client, env.VERSION ?? 'unknown');
 
-    // Stateless transport — new instance per request for Cloudflare Workers
+    // Stateless transport — new instance per request for Cloudflare Workers.
+    // enableJsonResponse avoids SSE streaming for POST responses, which is more reliable
+    // in a stateless per-request execution model.
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
+      enableJsonResponse: true,
     });
     await server.connect(transport);
 


### PR DESCRIPTION
## Problem

Cloudflare Workers were being killed with a \"hung\" error on `GET /mcp` requests:

> The Workers runtime canceled this request because it detected that your Worker's code had hung and would never generate a response.

## Root Cause

MCP clients (per the Streamable HTTP spec) send a `GET /mcp` request with `Accept: text/event-stream` to open a persistent SSE channel for server-initiated notifications. The SDK's `handleGetRequest` creates a `ReadableStream` and returns a `Response` wrapping it — but this stream is designed to stay open indefinitely. It only closes if the client disconnects or `closeStandaloneSSEStream()` is called explicitly.

In our **stateless, per-request** Worker:
- There is no persistent server instance that could push events into the stream
- The open `ReadableStream` never writes any data and never closes
- Cloudflare's runtime detects this and kills the Worker

## Fix

- **Intercept `GET /mcp` with `405 Method Not Allowed`** — server-initiated SSE messages are not supported in a stateless per-request execution model, so the GET stream is both meaningless and harmful
- **Add `enableJsonResponse: true` to the transport** — makes POST responses return plain `application/json` instead of SSE, which is more reliable for stateless Workers and avoids holding an open stream while waiting for tool handlers

Made with [Cursor](https://cursor.com)