### PR TITLE
feat: upload media to DA from a public sourceUrl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ All tools accept `org` and `repo` parameters plus operation-specific params:
 | `da_get_versions` | Get version history |
 | `da_lookup_media` | Get media asset info |
 | `da_lookup_fragment` | Get fragment info |
-| `da_upload_media` | Upload binary media file |
+| `da_upload_media` | Upload binary media file from base64 data or a public `sourceUrl` |
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ src/
 | `da_get_versions` | Get version history for a file |
 | `da_lookup_media` | Lookup media references |
 | `da_lookup_fragment` | Lookup fragment references |
+| `da_upload_media` | Upload a media file from base64 data or a public `sourceUrl` (e.g. a Firefly temporary asset URL) |
 
 ## Prerequisites
 

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -372,9 +372,94 @@ export async function handleLookupFragment(
   }
 }
 
+const UPLOAD_FETCH_TIMEOUT = 30000; // 30 seconds, mirrors DAAdminClient
+
+/**
+ * Encode raw bytes to a base64 string.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binaryStr = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binaryStr += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binaryStr);
+}
+
+/**
+ * Derive a filename from an explicit override, a source URL, or the DA path.
+ */
+function deriveFileName(
+  override: string | undefined,
+  sourceUrl: string | undefined,
+  daPath: string,
+): string {
+  if (override && override.trim()) return override.trim();
+
+  if (sourceUrl) {
+    try {
+      const { pathname } = new URL(sourceUrl);
+      const urlName = pathname.split('/').filter(Boolean).pop();
+      if (urlName) return urlName;
+    } catch {
+      // fall through to DA path derivation
+    }
+  }
+
+  const pathName = daPath.split('/').filter(Boolean).pop();
+  return pathName || 'upload';
+}
+
+/**
+ * Fetch binary content from a public URL, returning base64 data and MIME type.
+ */
+async function fetchMediaFromUrl(
+  sourceUrl: string,
+  mimeTypeOverride: string | undefined,
+): Promise<{ base64Data: string; mimeType: string; byteSize: number }> {
+  let parsed: URL;
+  try {
+    parsed = new URL(sourceUrl);
+  } catch {
+    throw new Error(`Invalid sourceUrl: ${sourceUrl}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Unsupported URL scheme "${parsed.protocol}". Only http and https are allowed.`);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), UPLOAD_FETCH_TIMEOUT);
+
+  try {
+    const response = await fetch(sourceUrl, { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch sourceUrl (${response.status} ${response.statusText})`);
+    }
+
+    const contentType = response.headers.get('content-type');
+    const mimeType = (mimeTypeOverride
+      || (contentType ? contentType.split(';')[0].trim() : '')
+      || 'application/octet-stream');
+
+    const arrayBuffer = await response.arrayBuffer();
+    const bytes = new Uint8Array(arrayBuffer);
+
+    return { base64Data: bytesToBase64(bytes), mimeType, byteSize: bytes.length };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Timed out fetching sourceUrl after ${UPLOAD_FETCH_TIMEOUT}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 /**
  * Handler for da_upload_media tool
- * Uploads images and media files to DA repository
+ * Uploads images and media files to DA repository from either base64 data
+ * or a public URL (e.g. a Firefly temporary asset URL).
  */
 export async function handleUploadMedia(
   client: DAAdminClient,
@@ -382,25 +467,49 @@ export async function handleUploadMedia(
     org: string;
     repo: string;
     path: string;
-    base64Data: string;
-    mimeType: string;
-    fileName: string;
+    base64Data?: string;
+    sourceUrl?: string;
+    mimeType?: string;
+    fileName?: string;
   },
 ) {
   try {
-    // Remove data URL prefix if present (e.g., "data:image/png;base64,")
-    let cleanBase64 = args.base64Data;
-    if (cleanBase64.includes(',')) {
-      [, cleanBase64] = cleanBase64.split(',');
+    const hasBase64 = typeof args.base64Data === 'string' && args.base64Data.length > 0;
+    const hasSourceUrl = typeof args.sourceUrl === 'string' && args.sourceUrl.length > 0;
+
+    if (hasBase64 === hasSourceUrl) {
+      throw new Error(
+        'Provide exactly one of "base64Data" or "sourceUrl".',
+      );
     }
+
+    let cleanBase64: string;
+    let mimeType: string;
+    let byteSize: number | undefined;
+
+    if (hasSourceUrl) {
+      const fetched = await fetchMediaFromUrl(args.sourceUrl!, args.mimeType);
+      cleanBase64 = fetched.base64Data;
+      mimeType = fetched.mimeType;
+      byteSize = fetched.byteSize;
+    } else {
+      // Remove data URL prefix if present (e.g., "data:image/png;base64,")
+      cleanBase64 = args.base64Data!;
+      if (cleanBase64.includes(',')) {
+        [, cleanBase64] = cleanBase64.split(',');
+      }
+      mimeType = args.mimeType || 'application/octet-stream';
+    }
+
+    const fileName = deriveFileName(args.fileName, args.sourceUrl, args.path);
 
     const response = await client.uploadMedia(
       args.org,
       args.repo,
       args.path,
       cleanBase64,
-      args.mimeType,
-      args.fileName,
+      mimeType,
+      fileName,
     );
 
     // Return success with the media path for reference
@@ -411,8 +520,9 @@ export async function handleUploadMedia(
           text: JSON.stringify({
             message: `Media uploaded successfully to ${args.path}`,
             path: args.path,
-            fileName: args.fileName,
-            mimeType: args.mimeType,
+            fileName,
+            mimeType,
+            ...(hasSourceUrl ? { sourceUrl: args.sourceUrl, byteSize } : {}),
             ...response,
           }, null, 2),
         },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -124,7 +124,11 @@ export function createServer(client: DAAdminClient, version: string): McpServer 
   }, (args) => handleLookupFragment(client, args) as Promise<CallToolResult>);
 
   server.registerTool('da_upload_media', {
-    description: 'Upload an image or media file to a DA repository using base64-encoded data. '
+    description: 'Upload an image or media file to a DA repository. '
+      + 'Provide exactly one content source: either "base64Data" (base64-encoded bytes) '
+      + 'or "sourceUrl" (a public http/https URL the server fetches directly, e.g. a Firefly '
+      + 'temporary asset URL with a short TTL). When using "sourceUrl", "mimeType" and "fileName" '
+      + 'are auto-derived from the response and URL if not provided. '
       + 'When uploading images referenced in a page (e.g. during page creation or update), '
       + 'place the image in a child folder named after the page, sibling to the page file '
       + '(e.g. page at "docs/my-page.html" → image at "docs/.my-page/image.png" with the folder name with a leading dot). '
@@ -138,9 +142,19 @@ export function createServer(client: DAAdminClient, version: string): McpServer 
         + 'For page-related images use a dot-prefixed folder named after the page: "docs/.my-page/image.png". '
         + 'For standalone uploads use the media folder: "media/image.png".',
       ),
-      base64Data: z.string().describe('Base64-encoded file content'),
-      mimeType: z.string().describe('MIME type of the file (e.g., "image/png", "image/jpeg")'),
-      fileName: z.string().describe('Original filename including extension (e.g., "photo.jpg")'),
+      base64Data: z.string().optional().describe('Base64-encoded file content. Provide this OR "sourceUrl", not both.'),
+      sourceUrl: z.string().url().optional().describe(
+        'Public http/https URL to fetch the media from (e.g. a Firefly temporary asset URL). '
+        + 'Provide this OR "base64Data", not both.',
+      ),
+      mimeType: z.string().optional().describe(
+        'MIME type of the file (e.g., "image/png", "image/jpeg"). '
+        + 'Optional when using "sourceUrl" — derived from the response Content-Type if omitted.',
+      ),
+      fileName: z.string().optional().describe(
+        'Original filename including extension (e.g., "photo.jpg"). '
+        + 'Optional when using "sourceUrl" — derived from the URL or destination path if omitted.',
+      ),
     }),
   }, (args) => handleUploadMedia(client, args) as Promise<CallToolResult>);
 

--- a/test/mcp/handlers.test.ts
+++ b/test/mcp/handlers.test.ts
@@ -1,5 +1,5 @@
 import {
-  describe, it, expect, vi, beforeEach,
+  describe, it, expect, vi, beforeEach, afterEach,
 } from 'vitest';
 import {
   handleListSources,
@@ -247,6 +247,10 @@ describe('Handler path normalization', () => {
   });
 
   describe('handleUploadMedia', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     it('should strip data URL prefix before uploading', async () => {
       await handleUploadMedia(mockClient, {
         org: 'test',
@@ -265,6 +269,154 @@ describe('Handler path normalization', () => {
         'image/png',
         'image.png',
       );
+    });
+
+    it('should fetch from sourceUrl and upload with derived mimeType and fileName', async () => {
+      const bytes = new Uint8Array([102, 111, 111]); // "foo" → base64 "Zm9v"
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? 'image/jpeg; charset=utf-8' : null) },
+        arrayBuffer: async () => bytes.buffer,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await handleUploadMedia(mockClient, {
+        org: 'test',
+        repo: 'repo',
+        path: 'docs/.my-page/hero.jpg',
+        sourceUrl: 'https://firefly.example.com/assets/generated-image.jpg',
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://firefly.example.com/assets/generated-image.jpg',
+        expect.objectContaining({ signal: expect.anything() }),
+      );
+      expect(mockClient.uploadMedia).toHaveBeenCalledWith(
+        'test',
+        'repo',
+        'docs/.my-page/hero.jpg',
+        'Zm9v',
+        'image/jpeg',
+        'generated-image.jpg',
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should prefer explicit mimeType and fileName over derived values', async () => {
+      const bytes = new Uint8Array([102, 111, 111]);
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get: () => 'image/jpeg' },
+        arrayBuffer: async () => bytes.buffer,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await handleUploadMedia(mockClient, {
+        org: 'test',
+        repo: 'repo',
+        path: 'media/x.bin',
+        sourceUrl: 'https://firefly.example.com/assets/generated-image.jpg',
+        mimeType: 'image/png',
+        fileName: 'custom.png',
+      });
+
+      expect(mockClient.uploadMedia).toHaveBeenCalledWith(
+        'test',
+        'repo',
+        'media/x.bin',
+        'Zm9v',
+        'image/png',
+        'custom.png',
+      );
+    });
+
+    it('should fall back to application/octet-stream when no content-type is present', async () => {
+      const bytes = new Uint8Array([102, 111, 111]);
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get: () => null },
+        arrayBuffer: async () => bytes.buffer,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await handleUploadMedia(mockClient, {
+        org: 'test',
+        repo: 'repo',
+        path: 'media/asset',
+        sourceUrl: 'https://firefly.example.com/download',
+      });
+
+      expect(mockClient.uploadMedia).toHaveBeenCalledWith(
+        'test',
+        'repo',
+        'media/asset',
+        'Zm9v',
+        'application/octet-stream',
+        'download',
+      );
+    });
+
+    it('should error when both base64Data and sourceUrl are provided', async () => {
+      const result = await handleUploadMedia(mockClient, {
+        org: 'test',
+        repo: 'repo',
+        path: 'media/image.png',
+        base64Data: 'Zm9v',
+        sourceUrl: 'https://firefly.example.com/image.png',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(mockClient.uploadMedia).not.toHaveBeenCalled();
+    });
+
+    it('should error when neither base64Data nor sourceUrl is provided', async () => {
+      const result = await handleUploadMedia(mockClient, {
+        org: 'test',
+        repo: 'repo',
+        path: 'media/image.png',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(mockClient.uploadMedia).not.toHaveBeenCalled();
+    });
+
+    it('should error on non-http(s) URL schemes', async () => {
+      const result = await handleUploadMedia(mockClient, {
+        org: 'test',
+        repo: 'repo',
+        path: 'media/image.png',
+        sourceUrl: 'file:///etc/passwd',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(mockClient.uploadMedia).not.toHaveBeenCalled();
+    });
+
+    it('should error when the fetch response is not OK', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: { get: () => null },
+        arrayBuffer: async () => new Uint8Array().buffer,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await handleUploadMedia(mockClient, {
+        org: 'test',
+        repo: 'repo',
+        path: 'media/image.png',
+        sourceUrl: 'https://firefly.example.com/missing.png',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(mockClient.uploadMedia).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extend `da_upload_media` to accept a public `sourceUrl` (http/https) in addition to `base64Data`
- Worker fetches the asset server-side, auto-derives `mimeType` and `fileName`, and uploads to DA via the existing client path
- Enables persisting short-lived Firefly temporary URLs into DA so pages can reference stable DA paths

## Test plan
- [ ] `npm run test` — 69 tests pass (includes new `sourceUrl` handler cases)
- [ ] `npm run lint` and `npm run type-check`
- [ ] Start local worker (`npm run dev` or `npx wrangler dev --remote`) and call `da_upload_media` via MCP Inspector with a public image URL
- [ ] Confirm asset appears in DA at the returned `path` and resolves via `da_lookup_media`
- [ ] End-to-end: Firefly MCP generates image → pass temporary URL to `da_upload_media` → reference returned DA path in page content