### PR TITLE
fix: use public da-admin host so collab invalidation targets the right room

### DIFF
--- a/src/da-admin/client.ts
+++ b/src/da-admin/client.ts
@@ -63,7 +63,17 @@ export class DAAdminClient {
     const startTime = Date.now();
 
     try {
-      const request = new Request(`https://daadmin${endpoint}`, {
+      // Host must be the public da-admin origin (not a placeholder): da-admin
+      // forwards req.url verbatim to da-collab's syncadmin invalidation, which keys
+      // the Yjs room by the full URL string. A mismatched host invalidates a
+      // phantom room and leaves live collab sessions stale. The service binding
+      // routes by binding, so the host here only affects that propagated URL.
+      //
+      // NOTE: this hardcodes the PRODUCTION origin (admin.da.live). If we ever
+      // deploy an environment that connects to stage (stage-admin.da.live), this
+      // will invalidate the wrong collab room and must be fixed - e.g. thread the
+      // env-specific base URL through DAAdminClient instead of hardcoding here.
+      const request = new Request(`https://admin.da.live${endpoint}`, {
         ...requestOptions,
         headers,
         signal: controller.signal,


### PR DESCRIPTION
## Problem

`da_update_source` (and other write ops) updated content in da-admin, but the change did **not** appear in an open da-live collab (canvas) editor until a full browser reload.

Root cause is a Durable Object room mismatch:

- da-mcp calls da-admin over the service binding with a **placeholder host** (`https://daadmin`, `client.ts:66`). The service binding routes by binding, but that host stays in `req.url`.
- da-admin's `postSource` forwards `req.url` **verbatim** to da-collab's `syncadmin` invalidation (`da-admin/src/routes/source.js` → `notifyCollab`).
- da-collab keys each Yjs room by the **full URL string** via `env.rooms.idFromName(doc)`.

So the invalidation was addressed to `idFromName("https://daadmin/source/...")`, a phantom room, while the browser's live session is keyed on `idFromName("https://admin.da.live/source/...")` (built as `${DA_ADMIN}${pathname}` in da-live's `prose.js`). The real session was never invalidated → no socket close, no content push → stale until reload.

This affected **every user**, not just one — normal browser saves worked only because they carry the real `admin.da.live` host.

## Fix

Use the public production origin (`https://admin.da.live`) for the request URL so `req.url` matches the room the browser joined. The service binding still routes by binding; the host only affects the propagated URL.

## Caveat (noted in code comment)

This **hardcodes production**. The `ci` env binds to `da-admin-stage`, whose collab rooms use `stage-admin.da.live` — a stage deployment would need the env-specific host (thread `DA_ADMIN_BASE_URL` through `DAAdminClient`). Called out inline so it isn't missed.

## Verification

- `npm run type-check` — passes, 0 errors
- `npm run lint` — 0 errors (4 pre-existing `no-explicit-any` warnings, none from this change)
- `npm test` — 62/62 pass

Recommend confirming post-deploy by tailing the da-collab worker while running `da_update_source` on prod: the logged doc URL should now carry the `admin.da.live` host with **no** `[worker] Document not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)