### PR TITLE
feat: add inspect_fig and fig_get_entry MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 DA MCP is a remote Model Context Protocol (MCP) server for Document Authoring (DA). It provides LLM assistants with direct access to DA management operations via Cloudflare Workers with streamable HTTP transport.
 
-**Architecture flow:** MCP Client → Cloudflare Worker (11 tools) → DA Admin API (admin.da.live)
+**Architecture flow:** MCP Client → Cloudflare Worker (13 tools) → DA Admin API (admin.da.live); the two `*_fig` tools proxy to the fig-inspector Worker instead.
 
 ## Development Commands
 
@@ -70,6 +70,8 @@ All tools accept `org` and `repo` parameters plus operation-specific params:
 | `da_lookup_media` | Get media asset info |
 | `da_lookup_fragment` | Get fragment info |
 | `da_upload_media` | Upload binary media file |
+| `inspect_fig` | Parse a Figma `.fig` (via fig-inspector Worker) → text, tokens, images, thumbnail, canvas |
+| `fig_get_entry` | Fetch one `.fig` asset (thumbnail/image) as an image |
 
 ## Deployment
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export interface Env {
   ENVIRONMENT?: string;
   VERSION?: string;
   DA_ADMIN_API_TOKEN?: string; // Optional fallback token for testing
+  FIG_INSPECTOR_URL?: string; // Optional override for the fig-inspector Worker base URL
   daadmin: Fetcher; // Service binding to DA Admin worker
 }
 
@@ -98,7 +99,7 @@ export default {
 
     // Create fresh client + server per request to prevent cross-client data leaks
     const client = new DAAdminClient({ apiToken: token, daadminService: env.daadmin });
-    const server = createServer(client, env.VERSION ?? 'unknown');
+    const server = createServer(client, env.VERSION ?? 'unknown', env.FIG_INSPECTOR_URL);
 
     // Stateless transport — new instance per request for Cloudflare Workers.
     // enableJsonResponse avoids SSE streaming for POST responses, which is more reliable

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -430,3 +430,93 @@ export async function handleUploadMedia(
     };
   }
 }
+
+// ---------------------------------------------------------------------------
+// fig-inspector tools — parse a Figma .fig via the fig-inspector Worker.
+// These proxy to the deployed fig-inspector Worker; no DA Admin is involved.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve raw .fig bytes from either an inline base64 payload or a URL to
+ * fetch. Exactly one of `figBase64` / `sourceUrl` should be provided.
+ */
+async function resolveFigBytes(
+  args: { figBase64?: string; sourceUrl?: string },
+): Promise<Uint8Array> {
+  if (args.sourceUrl) {
+    const resp = await fetch(args.sourceUrl);
+    if (!resp.ok) throw new Error(`Failed to fetch sourceUrl (${resp.status})`);
+    return new Uint8Array(await resp.arrayBuffer());
+  }
+  if (args.figBase64) {
+    const binary = atob(args.figBase64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  }
+  throw new Error('Provide either figBase64 or sourceUrl');
+}
+
+/**
+ * Handler for inspect_fig — POST the .fig bytes to the fig-inspector Worker's
+ * /inspect endpoint and return the parsed structure (text runs, design tokens,
+ * image list, preview thumbnail, canvas metadata) as JSON.
+ */
+export async function handleInspectFig(
+  figInspectorUrl: string,
+  args: { figBase64?: string; sourceUrl?: string },
+) {
+  try {
+    const bytes = await resolveFigBytes(args);
+    const resp = await fetch(`${figInspectorUrl.replace(/\/$/, '')}/inspect`, {
+      method: 'POST',
+      body: bytes,
+    });
+    const text = await resp.text();
+    if (!resp.ok) {
+      return {
+        content: [{ type: 'text', text: `fig-inspector /inspect error (${resp.status}): ${text.slice(0, 500)}` }],
+        isError: true,
+      };
+    }
+    return { content: [{ type: 'text', text }] };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatError(error) }],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Handler for fig_get_entry — fetch one entry (e.g. "thumbnail.png" or
+ * "images/<hash>") from the .fig via the fig-inspector Worker's /entry
+ * endpoint, returned as an MCP image content block.
+ */
+export async function handleFigGetEntry(
+  figInspectorUrl: string,
+  args: { name: string; figBase64?: string; sourceUrl?: string },
+) {
+  try {
+    const bytes = await resolveFigBytes(args);
+    const url = `${figInspectorUrl.replace(/\/$/, '')}/entry?name=${encodeURIComponent(args.name)}`;
+    const resp = await fetch(url, { method: 'POST', body: bytes });
+    if (!resp.ok) {
+      const text = await resp.text();
+      return {
+        content: [{ type: 'text', text: `fig-inspector /entry error (${resp.status}): ${text.slice(0, 500)}` }],
+        isError: true,
+      };
+    }
+    const mimeType = resp.headers.get('content-type') || 'application/octet-stream';
+    const buf = new Uint8Array(await resp.arrayBuffer());
+    let binary = '';
+    for (let i = 0; i < buf.length; i += 1) binary += String.fromCharCode(buf[i]);
+    return { content: [{ type: 'image', data: btoa(binary), mimeType }] };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatError(error) }],
+      isError: true,
+    };
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,13 +19,22 @@ import {
   handleLookupMedia,
   handleUploadMedia,
   handleLookupFragment,
+  handleInspectFig,
+  handleFigGetEntry,
 } from './handlers';
+
+const DEFAULT_FIG_INSPECTOR_URL = 'https://fig-inspector.franklin-prod.workers.dev';
 
 /**
  * Create and configure MCP server with all DA tools registered
  */
-export function createServer(client: DAAdminClient, version: string): McpServer {
+export function createServer(
+  client: DAAdminClient,
+  version: string,
+  figInspectorUrl?: string,
+): McpServer {
   const server = new McpServer({ name: 'da-live-admin', version });
+  const figUrl = figInspectorUrl || DEFAULT_FIG_INSPECTOR_URL;
 
   server.registerTool('da_list_sources', {
     description: 'List all sources and directories in a DA repository at a given path. Returns a list of files and folders with their metadata.',
@@ -143,6 +152,27 @@ export function createServer(client: DAAdminClient, version: string): McpServer 
       fileName: z.string().describe('Original filename including extension (e.g., "photo.jpg")'),
     }),
   }, (args) => handleUploadMedia(client, args) as Promise<CallToolResult>);
+
+  server.registerTool('inspect_fig', {
+    description: 'Parse a Figma .fig file offline (no Figma token) and return its structure: '
+      + 'recovered text runs, design tokens, the image asset list, a preview thumbnail (base64), '
+      + 'and canvas metadata. Provide the .fig either inline as base64 (figBase64) or as a fetchable '
+      + 'URL (sourceUrl). Use this as the first step of converting a Figma design into an EDS landing page.',
+    inputSchema: z.object({
+      figBase64: z.string().optional().describe('Base64-encoded .fig file bytes. Provide this OR sourceUrl.'),
+      sourceUrl: z.string().optional().describe('URL to fetch the .fig from. Provide this OR figBase64.'),
+    }),
+  }, (args) => handleInspectFig(figUrl, args) as Promise<CallToolResult>);
+
+  server.registerTool('fig_get_entry', {
+    description: 'Fetch one asset from a .fig by name (e.g. "thumbnail.png" or an "images/<hash>" '
+      + 'entry from inspect_fig output), returned as an image. Provide the .fig via figBase64 or sourceUrl.',
+    inputSchema: z.object({
+      name: z.string().describe('Entry name, e.g. "thumbnail.png" or "images/<hash>".'),
+      figBase64: z.string().optional().describe('Base64-encoded .fig file bytes. Provide this OR sourceUrl.'),
+      sourceUrl: z.string().optional().describe('URL to fetch the .fig from. Provide this OR figBase64.'),
+    }),
+  }, (args) => handleFigGetEntry(figUrl, args) as Promise<CallToolResult>);
 
   return server;
 }


### PR DESCRIPTION
## Summary
Adds two MCP tools that parse a Figma `.fig` by proxying to the fig-inspector
Cloudflare Worker (a Rust→WASM parser). First step of a Figma → EDS
landing-page flow (upload a `.fig` in the EW chat → parse → author page).

## Tools
- **inspect_fig** — POST a `.fig` (`figBase64` or `sourceUrl`) → Worker `/inspect`
  → parsed JSON: text runs, design tokens, image list, preview thumbnail
  (base64), canvas metadata.
- **fig_get_entry** — fetch one asset (`thumbnail.png` / `images/<hash>`) →
  Worker `/entry` → returned as an image.

No Figma token, no DA Admin. Worker base URL defaults to the deployed
fig-inspector, overridable via `env.FIG_INSPECTOR_URL`.

## Changes
- `src/mcp/handlers.ts` — `handleInspectFig`, `handleFigGetEntry`, `resolveFigBytes`.
- `src/mcp/server.ts` — register both tools; `createServer` takes optional `figInspectorUrl`.
- `src/index.ts` — `FIG_INSPECTOR_URL` env passthrough.
- `CLAUDE.md` — tools table (13).

## Gating
Exposure is controlled at the **AO layer** — manifest `policy` include/exclude on
the namespaced `{server}__inspect_fig` / `__fig_get_entry`, or by shipping these
as a plugin `.mcp.json`. da-mcp registers them unconditionally so AO discovery
sees them. (A per-request gate was intentionally not used: AO doesn't forward
per-request UI state, and default-off would hide the tools from discovery.)

## Test plan
- type-check ✅, lint ✅ (0 errors), 62 tests ✅.
- Validated end-to-end against a real 6.7 MB `.fig`: `inspect_fig` → 12 images,
  1017 text runs, thumbnail; `fig_get_entry(thumbnail.png)` → image/png.
- Local: `npm run dev` → `localhost:8787/mcp`, call `inspect_fig`.

## Notes
- Payload: `figBase64` is fine ~7 MB; for larger files use `sourceUrl`.
- AO must **deploy** da-mcp to see the tools.

## Risk
Low — additive; existing tools/tests untouched; new tools are read-only parsers.